### PR TITLE
treat "Paramount Pictures", "Star Trek" in example text as non-Klingon

### DIFF
--- a/KlingonAssistant/data/mem-08-m.xml
+++ b/KlingonAssistant/data/mem-08-m.xml
@@ -296,7 +296,7 @@ This word does not have the sense of "good" as used in a greeting, such as "good
       <column name="hidden_notes">This is usually {malja' permey:n:nolink} in canon.</column>
       <column name="components"></column>
       <column name="examples">
-▶ {Paramount Pictures malja' permey bIH Star Trek pong'e' Deghmey'e' je.:sen:nolink}[2]</column>
+▶ Paramount Pictures {malja' permey bIH:sen:nolink} Star Trek {pong'e' Deghmey'e' je.:sen:nolink}[2]</column>
       <column name="search_tags"></column>
       <column name="source">[1] {STC 104:src}, [2] {SkyBox cards:src}</column>
     </table>

--- a/KlingonAssistant/data/mem-26-footer.xml
+++ b/KlingonAssistant/data/mem-26-footer.xml
@@ -522,7 +522,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
 ▶ {jIlujpu' jIH'e'.:sen:nolink} "I, and only I, have failed." or "It is I who has failed."[1]
 ▶ {pa'DajDaq ghaHtaH la''e'.:sen:nolink} "The commander is in his quarters."[2]
 ▶ {cheng'e' DaH Sam!:sen:nolink} "Find Chang!" (clipped)[6]
-▶ {Paramount Pictures malja' permey bIH Star Trek pong'e' Deghmey'e' je.:sen:nolink}[7]</column>
+▶ Paramount Pictures {malja' permey bIH:sen:nolink} Star Trek {pong'e' Deghmey'e' je.:sen:nolink}[7]</column>
       <column name="search_tags">noun type 5</column>
       <column name="source">[1] {TKD 3.3.5:src}, [2] {TKD 6.3:src}, [3] {TKDA 6.7:src}, [4] {HQ 4.2, p.5-6, Jun. 1995:src}, [5] {KGT p.23:src}, [6] {Star Trek VI:src}, [7] {SkyBox cards:src}</column>
     </table>


### PR DESCRIPTION
issue #140
