### PR TITLE
exactify explanation for tlhIngan Hol

### DIFF
--- a/KlingonAssistant/data/mem-17-tlh.xml
+++ b/KlingonAssistant/data/mem-17-tlh.xml
@@ -804,17 +804,17 @@ There is an idiom, {Hem; tlhIngan rur}.</column>
       <column name="_id">33701</column>
       <column name="entry_name">tlhIngan Hol</column>
       <column name="part_of_speech">n:deriv</column>
-      <column name="definition">Klingon (language)</column>
+      <column name="definition">Klingon language</column>
       <column name="definition_de">Klingonische Sprache</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan:n}, {Hol:n}</column>
       <column name="notes">This is short for {tlhIngan wo' Hol:n:nolink}.[2]</column>
-      <column name="hidden_notes">This term doesn't actually appear in the word lists in {TKD:src}, but is of course used throughout the book.</column>
+      <column name="hidden_notes">This term doesn't actually appear in the word lists in {TKD:src}, but is used in the list of useful expressions.</column>
       <column name="components">{tlhIngan:n}, {Hol:n}</column>
       <column name="examples"></column>
       <column name="search_tags"></column>
-      <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2012.04.01:src}</column>
+      <column name="source">[1] {TKD:src}, [1] {KGT:src}, [3] {KLI mailing list 2012.04.01:src}</column>
     </table>
     <table name="mem">
       <!-- Checked on: 2012.12.15. -->


### PR DESCRIPTION
The phrase {tlhIngan Hol} was used in TKD actually ONLY in the "List of useful expressions", so not really "throughout the book". The first time the term was really explained was on page 10 of KGT, where it says "literally: Klingon language" and adds "henceforth called Klingon."