### PR TITLE
Correct German translation error n/v for {Saj}

### DIFF
--- a/KlingonAssistant/data/mem-15-S.xml
+++ b/KlingonAssistant/data/mem-15-S.xml
@@ -153,7 +153,7 @@ Note that Klingon has words for "ten thousand" ({netlh:n:num}) and "hundred thou
       <column name="entry_name">Saj</column>
       <column name="part_of_speech">n</column>
       <column name="definition">pet</column>
-      <column name="definition_de">streicheln</column>
+      <column name="definition_de">Haustier</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'DIbaH:n:1}, {yach:v:1}</column>


### PR DESCRIPTION
pet was incorrectly translated as a verb instead of a noun into German.