### PR TITLE
added German translations for "use color" and "social networks"

### DIFF
--- a/KlingonAssistant/res/values-de/strings.xml
+++ b/KlingonAssistant/res/values-de/strings.xml
@@ -136,7 +136,12 @@
         <string name="xifan_hol_preference_summary">Erlaube \"x\" für {tlh}, \"f\" für {ng}, usw.</string>
         <string name="swap_qs_preference_title">{Q} und {q} tauschen</string>
         <string name="swap_qs_preference_summary">Nutze \"k\" als {q} und \"q\" als {Q}.</string>
+          <string name="social_preferences">Soziale Einstellungen</string>
+        <string name="social_network_preference_title">Soziales Netzwerk</string>
+        <string name="social_network_preference_summary">Soziales Netzwerk einstellen.</string>
       <string name="informational_preferences">Zusätzliche Informationen</string>
+        <string name="use_colours_preference_title">Farben verwenden</string>
+        <string name="use_colours_preference_summary">Verschiedene Wortarten farblich unterscheiden.</string>
         <string name="show_transitivity_preference_title">Transitivität</string>
         <string name="show_transitivity_preference_summary">Eine \"beste Vermutung\" anzeigen, ob ein Verb ein Objekt haben kann.</string>
         <string name="show_additional_information_preference_title">Zusatzinfos</string>
@@ -186,7 +191,7 @@
     <string name="tutorial_5_title">Andere Funktionen</string>
     <string name="tutorial_5_msg">Benutze den Menü-Button für weitere Funktionen.</string>
     <string name="tutorial_6_title">Noch mehr Funktionen</string>
-    <string name="tutorial_6_msg">Willst du hören, wie sich ein Wort anhört? Nutze den "Vorlese"-Button. (benötigt Klingonische Text-To-Speech engine.)\n\nLiset du einen langen Text auf Klingonisch (wie Hamlet)? Aktiviere den Schwimm-Modus, und boQwI\' schwebt über deinen Browser, dein Emailprogramm oder E-Book-Reader.</string>
+    <string name="tutorial_6_msg">Willst du hören, wie sich ein Wort anhört? Nutze den "Vorlese"-Button. (benötigt Klingonische Text-To-Speech engine.)\n\nLiest du einen langen Text auf Klingonisch (wie Hamlet)? Aktiviere den Schwimm-Modus, und boQwI\' schwebt über deinen Browser, dein E-Mailprogramm oder E-Book-Reader.</string>
     <string name="tutorial_7_title">Qapla\'! (Erfolg!)</string>
     <string name="tutorial_7_msg">Fortgeschrittene Nutzer finden weitere Optionen im Einstellungs-Menü.</string>
     -->


### PR DESCRIPTION
Added missing German phrase for the menu items "social network"  and "use color for different pars of speech" + correct two typos.