### PR TITLE
German for qep'a' 2017 - other 2

### DIFF
--- a/KlingonAssistant/data/mem-06-j.xml
+++ b/KlingonAssistant/data/mem-06-j.xml
@@ -1268,7 +1268,7 @@ There is also an idiom, {jej; Daqtagh rur}.</column>
       <column name="entry_name">jel</column>
       <column name="part_of_speech">v:i_c</column>
       <column name="definition">shake, tremble</column>
-      <column name="definition_de"></column>
+      <column name="definition_de">wackeln, zittern</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qom:v:1}, {tav:v}, {wal:v}</column>
@@ -2192,7 +2192,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="entry_name">jItuj'ep</column>
       <column name="part_of_speech">n</column>
       <column name="definition">mummy</column>
-      <column name="definition_de"></column>
+      <column name="definition_de">Mumie</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pe'laQ:n:2}</column>
@@ -2211,7 +2211,7 @@ To express a wish for something to happen, see {-jaj:v}.</column>
       <column name="entry_name">jItuj'ep ngutlh</column>
       <column name="part_of_speech">n:deriv</column>
       <column name="definition">mummification glyph</column>
-      <column name="definition_de"></column>
+      <column name="definition_de">Mumien-Zeichen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2365,7 +2365,7 @@ The first half of the example sentence was a lip-match for {ghaH vISammeH}.</col
       <column name="entry_name">job</column>
       <column name="part_of_speech">v:is</column>
       <column name="definition">zigzag, be jagged</column>
-      <column name="definition_de"></column>
+      <column name="definition_de">zickzackförmig</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>


### PR DESCRIPTION
added translations for new words revealed at qep'a' 2017. Here: other 2