### PR TITLE
 German for qep'a' 2017 - word for predict

### DIFF
--- a/KlingonAssistant/data/mem-12-q.xml
+++ b/KlingonAssistant/data/mem-12-q.xml
@@ -4404,12 +4404,12 @@ This word can't be used for a hole in the ground (for which see {QemjIq:n}), but
       <column name="entry_name">qut</column>
       <column name="part_of_speech">v:t_c</column>
       <column name="definition">predict</column>
-      <column name="definition_de"></column>
+      <column name="definition_de">vorhersagen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aq:v}, {ghut:v}</column>
       <column name="notes">This refers to making a prediction which is fraudulent or suspected to be fraudulent, or if it's a carnival act or the like.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies ist eine Vorhersage, wie es unechte Wahrsager machen, d.h. ohne wahre Fakten.</column>
       <column name="hidden_notes">That is, this is a prediction made based on a crystal ({qut:n}) ball.</column>
       <column name="components"></column>
       <column name="examples"></column>


### PR DESCRIPTION
added translations for new words revealed at qep'a' 2017. Here: predict (fraudulent)