### PR TITLE
German for qep'a' 2017 - SanDIy

### DIFF
--- a/KlingonAssistant/data/mem-15-S.xml
+++ b/KlingonAssistant/data/mem-15-S.xml
@@ -258,12 +258,12 @@ Note that Klingon has words for "ten thousand" ({netlh:n:num}) and "hundred thou
       <column name="entry_name">SanDIy</column>
       <column name="part_of_speech">n</column>
       <column name="definition">scar</column>
-      <column name="definition_de"></column>
+      <column name="definition_de">Narbe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taq:v}, {roptoj:n}, {mIvwa':n}</column>
       <column name="notes">This is a scar which is the result of a wound received in the course of a fight or battle.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies ist eine Narbe als Resultat einer Kampf-Verletzung.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>


### PR DESCRIPTION
added translations for new words revealed at qep'a' 2017. Here: SanDIy