### PR TITLE
fix DE-entry for {van}

### DIFF
--- a/KlingonAssistant/data/mem-18-v.xml
+++ b/KlingonAssistant/data/mem-18-v.xml
@@ -434,12 +434,12 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="entry_name">van</column>
       <column name="part_of_speech">v:2,t</column>
       <column name="definition">end (an event, voyage, battle, play, opera, story, song, etc.)</column>
-      <column name="definition_de">Ende (von Reise, Kampf, Spiel, Oper, Lied usw.)</column>
+      <column name="definition_de">beenden (eine Reise, Kampf, Spiel, Oper, Lied usw.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bertlham:n}, {Dor:v:2}, {ghang:v}, {rIn:v}, {'o'megh:n}, {van:v:1}</column>
       <column name="notes">The subject of this verb is the person causing an event to end. The object is the event that is ended. If the event was prematurely brought to an end, use {ghang:v} instead. To describe the ending of a period of time, use {Dor:v:2} instead.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Das Subjekt dieses Verbes ist die Person, die ein Ereignis beendet. Das Objekt ist das Ereignis, welches beendet wird. Falls das Ereignis vorzeitig beendet wird, benutzt man {ghang:v} stattdessen. Um das Enden eines Zeitabschnitts zu beschreiben, verwendet man {Dor:v:2}.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -477,7 +477,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">A planet in the Gamma Quadrant.</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Ein Planet im Gamma Quadranten.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -572,7 +572,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="entry_name">vang</column>
       <column name="part_of_speech">v:i</column>
       <column name="definition">act, take action</column>
-      <column name="definition_de">handeln, etwas machen</column>
+      <column name="definition_de">handeln, agieren</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -932,7 +932,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="antonyms"></column>
       <column name="see_also"></column>
       <column name="notes">This means "Learn from your experiences."</column>
-      <column name="notes_de"></column>
+      <column name="notes_de">Dies bedeutet "Lerne von deinen Erfahrungen."</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1061,8 +1061,8 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples">
 ▶ {veH Qav 'oH logh'e':sen}</column>
       <column name="examples_de"></column>
-      <column name="search_tags">border, frontier</column>
-      <column name="search_tags_de"></column>
+      <column name="search_tags">border, frontier, barrier</column>
+      <column name="search_tags_de">Rand, Abgrenzung, Barriere</column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">


### PR DESCRIPTION
The word was incorrectly translated as a noun (Ende) instead of a verb (beenden). This error occured because in English, "end" can be both noun and verb.